### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,11 +20,16 @@ on:
       - 'backend/**'
       - '.github/workflows/backend.yml'
 
+permissions:
+  contents: read
+
 jobs:
   generate-lockfile:
     name: Generate lockfile
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request'}}
+    permissions:
+      contents: write
 
     outputs:
       files_changed: ${{ steps.verify-changed-files.outputs.files_changed }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,8 +28,6 @@ jobs:
     name: Generate lockfile
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request'}}
-    permissions:
-      contents: write
 
     outputs:
       files_changed: ${{ steps.verify-changed-files.outputs.files_changed }}

--- a/.github/workflows/compress-images.yml
+++ b/.github/workflows/compress-images.yml
@@ -16,6 +16,10 @@ on:
       - '**.webp'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   compress-images:
     name: Compress images

--- a/.github/workflows/frontend-admin.yml
+++ b/.github/workflows/frontend-admin.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'frontend-admin/**'
       - '.github/workflows/frontend-admin.yml'
+
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests

--- a/.github/workflows/frontend-base-workflow.yml
+++ b/.github/workflows/frontend-base-workflow.yml
@@ -22,6 +22,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'
+
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -7,6 +7,9 @@ on:
       - 'backend/**'
       - '.github/workflows/schema-validation.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-schema:
     name: OpenAPI schema validation


### PR DESCRIPTION
Fixes CodeQL "Workflow does not contain permissions" alerts by declaring minimal `GITHUB_TOKEN` scopes on every workflow