### PR TITLE
Fix duplicate users on social login + format_html

### DIFF
--- a/backend/common/admin.py
+++ b/backend/common/admin.py
@@ -23,7 +23,7 @@ class UserProfileAdmin(ModelAdmin):
     @admin.display(description="Link to User")
     def user_link(self, obj):
         url = reverse("admin:auth_user_change", args=(obj.user.id,))
-        return format_html(f'<a href="{url}">{obj.user.get_full_name()}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.user.get_full_name())
 
 
 class ExtendedUserAdmin(UserAdmin):

--- a/backend/common/social_core/pipeline.py
+++ b/backend/common/social_core/pipeline.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from libgravatar import Gravatar, sanitize_email
 from rest_framework.exceptions import AuthenticationFailed, ValidationError
-from social_core.exceptions import NotAllowedToDisconnect
+from social_core.exceptions import AuthException, NotAllowedToDisconnect
 from social_django.models import UserSocialAuth
 
 logger = logging.getLogger(__name__)
@@ -15,6 +15,29 @@ logger = logging.getLogger(__name__)
 def check_for_email(details, *args, **kwargs):
     if not details.get("email"):
         raise ValidationError("Email was not provided by OAuth provider.")
+
+
+def associate_by_email(backend, details, user=None, *args, **kwargs):
+    """
+    Drop-in replacement for social_core.pipeline.social_auth.associate_by_email
+    that also matches inactive accounts created by the anonymous request flow.
+    """
+    if user:
+        return None
+
+    email = details.get("email")
+    if not email:
+        return None
+
+    user_model = backend.strategy.storage.user.user_model()
+    users = list(user_model.objects.filter(email__iexact=email))
+    if len(users) == 0:
+        return None
+    if len(users) > 1:
+        raise AuthException(
+            backend, "The given email address is associated with another account"
+        )
+    return {"user": users[0], "is_new": False}
 
 
 def check_if_user_is_banned(backend, user=None, *args, **kwargs):

--- a/backend/core/settings/_auth_social.py
+++ b/backend/core/settings/_auth_social.py
@@ -82,9 +82,10 @@ SOCIAL_AUTH_PIPELINE = (
     # Make up a username for this person, appends a random string at the end if
     # there's any collision.
     "social_core.pipeline.user.get_username",
-    # Associates the current social details with another user account with
-    # a similar email address. Disabled by default.
-    "social_core.pipeline.social_auth.associate_by_email",
+    # Custom action: Associates the current social details with another user
+    # account with the same email address, including inactive placeholder
+    # accounts created by the anonymous request flow.
+    "common.social_core.pipeline.associate_by_email",
     # Custom action: Check if user has been banned.
     "common.social_core.pipeline.check_if_user_is_banned",
     # Custom action: Check if there is only one account from a provider is connected to a user.

--- a/backend/tests/api/v1/login/login_oauth2_tests.py
+++ b/backend/tests/api/v1/login/login_oauth2_tests.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import responses
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.test import override_settings
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -305,3 +306,28 @@ class MicrosoftOAuth2Test(OAuth2Test):
     @responses.activate
     def test_login(self):
         self.do_rest_login("microsoft-graph")
+
+    @responses.activate
+    def test_login_matches_inactive_placeholder_account(self):
+        # Anonymous request flow creates inactive placeholder accounts with the
+        # requester's email. The first social login must match such an account
+        # instead of creating a duplicate user.
+        UserModel = get_user_model()
+        placeholder = UserModel.objects.create_user(
+            username="foobar@foobar.com",
+            email="foobar@foobar.com",
+            is_active=False,
+        )
+        placeholder.set_unusable_password()
+        placeholder.save()
+
+        self.do_rest_login("microsoft-graph")
+
+        placeholder.refresh_from_db()
+        self.assertTrue(placeholder.is_active)
+        self.assertEqual(
+            UserModel.objects.filter(email__iexact="foobar@foobar.com").count(), 1
+        )
+        self.assertTrue(
+            placeholder.social_auth.filter(provider="microsoft-graph").exists()
+        )

--- a/backend/video_requests/admin.py
+++ b/backend/video_requests/admin.py
@@ -2,7 +2,8 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.db.models import Avg, Count
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 from simple_history.admin import SimpleHistoryAdmin
 
 from video_requests.models import Comment, CrewMember, Rating, Request, Todo, Video
@@ -33,7 +34,7 @@ class RequestHistoryAdmin(SimpleHistoryAdmin):
     @admin.display(description="Requester")
     def requester_link(self, obj):
         url = reverse("admin:auth_user_change", args=(obj.requester.id,))
-        return format_html(f'<a href="{url}">{obj.requester.get_full_name()}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.requester.get_full_name())
 
     def save_model(self, request, obj, form, change):
         if not change:
@@ -49,12 +50,12 @@ class CrewMemberHistoryAdmin(SimpleHistoryAdmin):
     @admin.display(description="Request")
     def request_link(self, obj):
         url = reverse("admin:video_requests_request_change", args=(obj.request.id,))
-        return format_html(f'<a href="{url}">{obj.request.title}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.request.title)
 
     @admin.display(description="Crew Member")
     def member_link(self, obj):
         url = reverse("admin:auth_user_change", args=(obj.member.id,))
-        return format_html(f'<a href="{url}">{obj.member.get_full_name()}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.member.get_full_name())
 
 
 @admin.register(Video)
@@ -68,7 +69,7 @@ class VideoHistoryAdmin(SimpleHistoryAdmin):
     @admin.display(description="Request")
     def request_link(self, obj):
         url = reverse("admin:video_requests_request_change", args=(obj.request.id,))
-        return format_html(f'<a href="{url}">{obj.request.title}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.request.title)
 
     @admin.display(description="Average Rating")
     def avg_rating(self, obj):
@@ -87,12 +88,12 @@ class CommentHistoryAdmin(SimpleHistoryAdmin):
     @admin.display(description="Request")
     def request_link(self, obj):
         url = reverse("admin:video_requests_request_change", args=(obj.request.id,))
-        return format_html(f'<a href="{url}">{obj.request.title}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.request.title)
 
     @admin.display(description="Author")
     def author_link(self, obj):
         url = reverse("admin:auth_user_change", args=(obj.author.id,))
-        return format_html(f'<a href="{url}">{obj.author.get_full_name()}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.author.get_full_name())
 
 
 @admin.register(Rating)
@@ -113,12 +114,12 @@ class RatingHistoryAdmin(SimpleHistoryAdmin):
     @admin.display(description="Video")
     def video_link(self, obj):
         url = reverse("admin:video_requests_video_change", args=(obj.video.id,))
-        return format_html(f'<a href="{url}">{obj.video.title}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.video.title)
 
     @admin.display(description="Author")
     def author_link(self, obj):
         url = reverse("admin:auth_user_change", args=(obj.author.id,))
-        return format_html(f'<a href="{url}">{obj.author.get_full_name()}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.author.get_full_name())
 
 
 @admin.register(Todo)
@@ -136,21 +137,25 @@ class TodoAdmin(ModelAdmin):
     @admin.display(description="Request")
     def request_link(self, obj):
         url = reverse("admin:video_requests_request_change", args=(obj.request.id,))
-        return format_html(f'<a href="{url}">{obj.request.title}</a>')
+        return format_html('<a href="{}">{}</a>', url, obj.request.title)
 
     @admin.display(description="Video")
     def video_link(self, obj):
         if obj.video:
             url = reverse("admin:video_requests_video_change", args=(obj.video.id,))
-            return format_html(f'<a href="{url}">{obj.video.title}</a>')
+            return format_html('<a href="{}">{}</a>', url, obj.video.title)
         return None
 
     @admin.display(description="Assignees")
     def assignee_names(self, obj):
-        names = ""
-        for assignee in obj.assignees.all():
-            url = reverse("admin:auth_user_change", args=(assignee.id,))
-            names += f'<a href="{url}">{assignee.get_full_name_eastern_order()}</a>&comma;&nbsp;'
-        if names:
-            names = names[:-13]
-        return format_html(names)
+        return format_html_join(
+            mark_safe("&comma;&nbsp;"),  # nosec B308
+            '<a href="{}">{}</a>',
+            (
+                (
+                    reverse("admin:auth_user_change", args=(assignee.id,)),
+                    assignee.get_full_name_eastern_order(),
+                )
+                for assignee in obj.assignees.all()
+            ),
+        )


### PR DESCRIPTION
## Summary
- Replace `social_core.pipeline.social_auth.associate_by_email` with a local step that also matches inactive accounts. The anonymous request flow creates placeholder users with `is_active=False`, and the upstream step routes through `social_django`'s `filter_active_users`, so the placeholder was invisible to the first social login and a duplicate account was created (e.g. user 299 → user 300 for the same email). `set_user_active_when_first_logs_in` activates the matched account immediately afterwards.
- Convert every `format_html` f-string call in `video_requests/admin.py` `TodoAdmin.assignee_names` with `format_html_join`. Django 6.0 removed the single-argument form; placeholder form also auto-escapes the interpolated titles/names.