### PR TITLE
Fix TimeAgo locale crash under Vite 8

### DIFF
--- a/frontend-admin/src/index.tsx
+++ b/frontend-admin/src/index.tsx
@@ -14,7 +14,7 @@ import {
 } from 'react-router';
 import { RouterProvider } from 'react-router/dom';
 import { register } from 'timeago.js';
-import huLocal from 'timeago.js/lib/lang/hu';
+import huLocal from 'timeago.js/esm/lang/hu';
 
 import { getName } from 'helpers/LocalStorageHelper';
 import { ThemeProvider } from 'providers/ThemeProvider';


### PR DESCRIPTION
## Problem
`<TimeAgo>` crashed at runtime with:
```
TypeError: localeFunc is not a function
    at formatDiff (timeago.js)
    at format (timeago.js)
    at TimeAgo (TimeAgo.tsx:46)
```
Vite 8 switched the bundler to Rolldown, which changed how CJS default imports interop. `import huLocal from 'timeago.js/lib/lang/hu'` (a CJS module using `exports.default = fn`) now resolves to the module namespace object `{ default: fn }` instead of the function itself. `register('hu_HU', huLocal)` stored that object, and `formatDiff` later called it as `localeFunc(...)` → not a function → component crash.

## Fix
Import the package's ESM build, which has a true `export default`:

```diff
-import huLocal from 'timeago.js/lib/lang/hu';
+import huLocal from 'timeago.js/esm/lang/hu';
```