### PR TITLE
Log real client IP instead of reverse proxy address

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -14,6 +14,7 @@ HEALTH_CHECK_URL_TOKEN = randomGeneratedToken  # Optional. Default: None. If set
 LANGUAGE_CODE = hu-hu  # Optional. Default: en-us
 SPECTACULAR_SERVE_SCHEMA = False  # Optional. Default: False. When enabled OpenAPI schema will be served under /api/v1/schema. Swagger UI and Redoc will also be available.
 TIME_ZONE = Europe/Budapest  # Optional. Default: Europe/Budapest
+TRUSTED_PROXY_CIDRS = 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16  # Optional. Default: loopback + RFC1918.
 
 ##########################
 # Database settings:

--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -1,5 +1,8 @@
 import logging
 import time
+from ipaddress import ip_address
+
+from django.conf import settings
 
 logger = logging.getLogger("api.access")
 
@@ -7,6 +10,30 @@ logger = logging.getLogger("api.access")
 class RequestLoggingMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
+
+    @staticmethod
+    def _client_ip(request):
+        remote_addr = request.META.get("REMOTE_ADDR")
+        forwarded = request.headers.get("x-forwarded-for")
+        if not forwarded:
+            return remote_addr
+
+        # Walk hops from the right (unspoofable REMOTE_ADDR outward) and skip
+        # trusted proxies: the first untrusted address is the real client.
+        # Client-forged entries sit on the left, so they can never pass as a proxy.
+        chain = [part.strip() for part in forwarded.split(",") if part.strip()]
+        chain.append(remote_addr)
+
+        for candidate in reversed(chain):
+            try:
+                addr = ip_address(candidate)
+            except ValueError:
+                continue
+            if any(addr in network for network in settings.TRUSTED_PROXY_CIDRS):
+                continue
+            return candidate
+
+        return remote_addr
 
     def __call__(self, request):
         start = time.monotonic()
@@ -21,7 +48,7 @@ class RequestLoggingMiddleware:
                 response.status_code,
                 duration_ms,
                 getattr(request.user, "id", None),
-                request.META.get("REMOTE_ADDR"),
+                self._client_ip(request),
             )
 
         return response

--- a/backend/common/tests.py
+++ b/backend/common/tests.py
@@ -198,3 +198,10 @@ class ClientIPResolutionTestCase(TestCase):
             self._resolve("172.21.0.3", forwarded="not-an-ip, 203.0.113.7"),
             "203.0.113.7",
         )
+
+    def test_all_entries_unparseable_falls_back_to_remote_addr(self):
+        # Even REMOTE_ADDR fails to parse; the loop exhausts and returns it.
+        self.assertEqual(
+            self._resolve("garbage", forwarded="also-bad"),
+            "garbage",
+        )

--- a/backend/common/tests.py
+++ b/backend/common/tests.py
@@ -5,9 +5,10 @@ from io import StringIO
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from rest_framework import status
 
+from common.middleware import RequestLoggingMiddleware
 from common.models import Ban, get_sentinel_user
 from common.templatetags.extra_tags import settings_value
 from tests.helpers.users_test_utils import create_user
@@ -147,4 +148,53 @@ class CommonTestCase(TestCase):
         self.assertIn(
             "Users cannot ban themselves.",
             context.exception.messages[0],
+        )
+
+
+class ClientIPResolutionTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _resolve(self, remote_addr, forwarded=None):
+        request = self.factory.get("/")
+        request.META["REMOTE_ADDR"] = remote_addr
+        if forwarded is None:
+            request.META.pop("HTTP_X_FORWARDED_FOR", None)
+        else:
+            request.META["HTTP_X_FORWARDED_FOR"] = forwarded
+        return RequestLoggingMiddleware._client_ip(request)
+
+    def test_no_forwarded_header_returns_remote_addr(self):
+        self.assertEqual(self._resolve("172.21.0.3"), "172.21.0.3")
+
+    def test_single_trusted_proxy_returns_real_client(self):
+        # peer is the trusted proxy; client sits left of it.
+        self.assertEqual(
+            self._resolve("172.21.0.3", forwarded="203.0.113.7"), "203.0.113.7"
+        )
+
+    def test_multiple_trusted_proxies_are_skipped(self):
+        self.assertEqual(
+            self._resolve("172.21.0.3", forwarded="203.0.113.7, 10.0.0.5, 192.168.1.2"),
+            "203.0.113.7",
+        )
+
+    def test_client_spoofed_entry_is_ignored(self):
+        # Client prepends a fake internal IP; it stays left of the real hop and
+        # must not be mistaken for the client.
+        self.assertEqual(
+            self._resolve("172.21.0.3", forwarded="10.9.9.9, 203.0.113.7"),
+            "203.0.113.7",
+        )
+
+    def test_all_hops_trusted_falls_back_to_remote_addr(self):
+        self.assertEqual(
+            self._resolve("172.21.0.3", forwarded="10.0.0.1, 192.168.0.1"),
+            "172.21.0.3",
+        )
+
+    def test_malformed_entries_are_skipped(self):
+        self.assertEqual(
+            self._resolve("172.21.0.3", forwarded="not-an-ip, 203.0.113.7"),
+            "203.0.113.7",
         )

--- a/backend/core/settings/base.py
+++ b/backend/core/settings/base.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 """
 
 from datetime import timedelta
+from ipaddress import ip_network
 from pathlib import Path
 from re import match
 
@@ -38,6 +39,16 @@ SECRET_KEY = config("APP_SECRET_KEY", default=get_random_secret_key())
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="", cast=Csv())
 CORS_ALLOWED_ORIGINS = config("CORS_ALLOWED_ORIGINS", default="", cast=Csv())
 CSRF_TRUSTED_ORIGINS = config("CSRF_TRUSTED_ORIGINS", default="", cast=Csv())
+
+# Trusted reverse-proxy networks for resolving the client IP from X-Forwarded-For.
+TRUSTED_PROXY_CIDRS = [
+    ip_network(cidr, strict=False)
+    for cidr in config(
+        "TRUSTED_PROXY_CIDRS",
+        default="127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+        cast=Csv(),
+    )
+]
 
 # Application definition
 


### PR DESCRIPTION
## Problem

Access logs showed the reverse proxy's IP, not the client's:

```
GET /api/v1/admin/requests?... 401 8ms user=None ip=172.21.0.3
```

`172.21.0.3` is the Docker-internal nginx address. `RequestLoggingMiddleware` read `REMOTE_ADDR`, which is always the immediate TCP peer (the proxy).

## Fix

Resolve the client from `X-Forwarded-For`:
- Build the hop chain as `XFF entries + [REMOTE_ADDR]`.
- Walk it from the right (`REMOTE_ADDR` is the unspoofable TCP peer) and discard hops inside trusted-proxy networks.
- First untrusted address = real client.

This is spoof-safe: client-supplied XFF entries land left of the real hop, so they can never pass as a trusted proxy. Trusted networks come from the new `TRUSTED_PROXY_CIDRS` setting (default: loopback + RFC1918). Considered `django-ipware` but it matches proxies by string prefix, not real CIDR (`172.` would trust all of `172.0.0.0/8`). Stdlib `ipaddress` does proper subnet matching, so no dependency added.
