### PR TITLE
Fix avatar provider set without an avatar on OAuth login

### DIFF
--- a/backend/common/social_core/pipeline.py
+++ b/backend/common/social_core/pipeline.py
@@ -208,10 +208,11 @@ def get_avatar(backend, response, user, *args, **kwargs):
     except requests.exceptions.HTTPError:
         logger.debug("Gravatar not found for %s", user.email)
 
-    if not user.userprofile.avatar.get("provider", None) and backend.name in [
-        "google-oauth2",
-        "microsoft-graph",
-    ]:
+    if (
+        not user.userprofile.avatar.get("provider", None)
+        and backend.name in ["google-oauth2", "microsoft-graph"]
+        and user.userprofile.avatar.get(backend.name)
+    ):
         user.userprofile.avatar["provider"] = backend.name
 
     user.save()

--- a/backend/tests/api/v1/login/login_oauth2_tests.py
+++ b/backend/tests/api/v1/login/login_oauth2_tests.py
@@ -331,3 +331,16 @@ class MicrosoftOAuth2Test(OAuth2Test):
         self.assertTrue(
             placeholder.social_auth.filter(provider="microsoft-graph").exists()
         )
+
+    @responses.activate
+    def test_login_without_avatar_does_not_set_provider(self):
+        # No Microsoft photo and no Gravatar must leave the provider unset, so
+        # UserProfile.full_clean() does not later reject the dangling provider.
+        responses.replace(responses.GET, self.avatar_image_url, status=404)
+
+        self.do_rest_login("microsoft-graph")
+
+        UserModel = get_user_model()
+        user = UserModel.objects.get(email__iexact="foobar@foobar.com")
+        self.assertIsNone(user.userprofile.avatar.get("provider"))
+        self.assertIsNone(user.userprofile.avatar_url)


### PR DESCRIPTION
## Problem

On Microsoft OAuth login, the avatar `provider` was set to `microsoft-graph` even when the user had no profile photo. The Graph photo request returns a non-200 status in that case, so the `microsoft-graph` avatar key is never stored leaving the `provider` pointing at a missing URL. The same latent bug applied to `google-oauth2` logins without a `picture`. A dangling provider fails later profile updates: `UserProfile.clean()` raises "Avatar does not exist for this provider." (and the saving signal can already fail at login time).

## Fix
Only fall back to the backend name as the avatar provider when that backend's avatar key was actually stored.