### PR TITLE
Ownership change and switch image signing to build provenance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
-  "name": "bss-request-manager",
+  "name": "request-manager",
   // Reuse the existing dev stack (postgres + redis) and add an `app` workspace
   // container on the same compose network so `postgres` / `redis` hostnames resolve.
   "dockerComposeFile": ["../docker-compose.dev.yaml", "docker-compose.yml"],
   "service": "app",
-  "workspaceFolder": "/workspaces/bss-request-manager",
+  "workspaceFolder": "/workspaces/request-manager",
   "features": {
     "ghcr.io/devcontainers/features/python:1": { "version": "3.14" },
     "ghcr.io/devcontainers/features/node:2": {
@@ -33,7 +33,7 @@
         "editorconfig.editorconfig"
       ],
       "settings": {
-        "python.defaultInterpreterPath": "/workspaces/bss-request-manager/backend/.venv/bin/python"
+        "python.defaultInterpreterPath": "/workspaces/request-manager/backend/.venv/bin/python"
       }
     }
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     # Source is resolved relative to the FIRST compose file's directory
     # (../docker-compose.dev.yaml at the repo root), so `.` is the repo root.
     volumes:
-      - .:/workspaces/bss-request-manager:cached
+      - .:/workspaces/request-manager:cached
     command: sleep infinity
     extra_hosts:
       - 'host.docker.internal:host-gateway'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,19 +31,13 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
+      # Mint the OIDC token and write the build provenance attestation.
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.2
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -96,17 +90,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
+      # Generate a build provenance attestation for the published image except on
+      # PRs. Stored as an OCI referrer (no extra tags) and shown under the repo's
+      # Attestations. Verify with:
+      #   gh attestation verify oci://ghcr.io/bsstudio/request-manager:main --owner BSStudio
+      # https://github.com/actions/attest-build-provenance
+      - name: Attest build provenance
         if: ${{ github.event_name != 'pull_request' }}
-        env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        uses: actions/attest-build-provenance@v4.1.1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 Workflow Support System for managing video shooting, filming and live-streaming
 requests of [Budavári Schönherz Stúdió](https://bsstudio.hu).
 
-[![Backend CI](https://github.com/KOliver94/bss-request-manager/actions/workflows/backend.yml/badge.svg)](https://github.com/KOliver94/bss-request-manager/actions/workflows/backend.yml)
-[![Frontend CI](https://github.com/KOliver94/bss-request-manager/actions/workflows/frontend.yml/badge.svg)](https://github.com/KOliver94/bss-request-manager/actions/workflows/frontend.yml)
-[![Frontend CI - Admin Dashboard](https://github.com/KOliver94/bss-request-manager/actions/workflows/frontend-admin.yml/badge.svg)](https://github.com/KOliver94/bss-request-manager/actions/workflows/frontend-admin.yml)
+[![Backend CI](https://github.com/BSStudio/request-manager/actions/workflows/backend.yml/badge.svg)](https://github.com/BSStudio/request-manager/actions/workflows/backend.yml)
+[![Frontend CI](https://github.com/BSStudio/request-manager/actions/workflows/frontend.yml/badge.svg)](https://github.com/BSStudio/request-manager/actions/workflows/frontend.yml)
+[![Frontend CI - Admin Dashboard](https://github.com/BSStudio/request-manager/actions/workflows/frontend-admin.yml/badge.svg)](https://github.com/BSStudio/request-manager/actions/workflows/frontend-admin.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 
 ## Overview

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [project]
-name = "bss-request-manager-backend"
+name = "request-manager-backend"
 authors = [
     {name = "Olivér Kecskeméty", email = "kecskemety.oliver@simonyi.bme.hu"}
 ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/koliver94/bss-request-manager:main
+    image: ghcr.io/bsstudio/request-manager:main
     restart: unless-stopped
     command: gunicorn --bind=0.0.0.0:8000 --workers=5 --threads=2 --timeout=60 --graceful-timeout=30 core.wsgi
     volumes:
@@ -16,7 +16,7 @@ services:
       - redis
 
   worker:
-    image: ghcr.io/koliver94/bss-request-manager:main
+    image: ghcr.io/bsstudio/request-manager:main
     restart: unless-stopped
     command: celery -A core worker
     env_file:
@@ -33,7 +33,7 @@ services:
       - redis
 
   beat:
-    image: ghcr.io/koliver94/bss-request-manager:main
+    image: ghcr.io/bsstudio/request-manager:main
     restart: unless-stopped
     command: celery -A core beat
     env_file:


### PR DESCRIPTION
- Rename `bss-request-manager` → `request-manager`, point refs at the `BSStudio` org (README badges,docker-compose image, devcontainer, pyproject).
- Replace cosign signing with `actions/attest-build-provenance` — provenance stored as an OCI referrerinstead of `.sig` tags, no more package/tag clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Infrastructure**
  - Updated containerized deployments to use the new Request Manager image location and workspace naming.
  - Added build provenance attestations to published container images for improved supply-chain transparency.

- **Documentation**
  - Updated project status badges to reference the current repository.
  - Renamed backend project metadata to align with the Request Manager product name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->