### PR TITLE
Fix breadcrumbs after React Router v8 upgrade

### DIFF
--- a/frontend-admin/src/components/Header/Breadcrumb/Breadcrumbs.tsx
+++ b/frontend-admin/src/components/Header/Breadcrumb/Breadcrumbs.tsx
@@ -10,10 +10,10 @@ type BreadcrumbsType = {
 }[];
 
 type ReactRouterUseMatchesType = {
-  data?: unknown;
   handle?: {
-    crumb: (data?: unknown) => string;
+    crumb: (loaderData?: unknown) => string;
   };
+  loaderData?: unknown;
   pathname: string;
 }[];
 
@@ -30,7 +30,7 @@ const Breadcrumbs = () => {
     // data to each one
     .map((match) => {
       return {
-        name: match.handle?.crumb(match.data) || '',
+        name: match.handle?.crumb(match.loaderData) || '',
         path: match.pathname,
       };
     });

--- a/frontend-admin/src/components/Header/Breadcrumb/Breadcrumbs.tsx
+++ b/frontend-admin/src/components/Header/Breadcrumb/Breadcrumbs.tsx
@@ -2,20 +2,26 @@ import { Fragment } from 'react';
 
 import { useIsFetching } from '@tanstack/react-query';
 import { ProgressSpinner } from 'primereact/progressspinner';
-import { href, Link, useMatches, useRouteError } from 'react-router';
+import {
+  href,
+  Link,
+  type UIMatch,
+  useMatches,
+  useRouteError,
+} from 'react-router';
 
 type BreadcrumbsType = {
   name: string;
   path: string;
 }[];
 
-type ReactRouterUseMatchesType = {
-  handle?: {
-    crumb: (loaderData?: unknown) => string;
-  };
-  loaderData?: unknown;
-  pathname: string;
-}[];
+type CrumbHandle =
+  | {
+      crumb: (loaderData?: unknown) => string;
+    }
+  | undefined;
+
+type ReactRouterUseMatchesType = UIMatch<unknown, CrumbHandle>[];
 
 const Breadcrumbs = () => {
   const error = useRouteError();


### PR DESCRIPTION
React Router v8 removed the deprecated `data` field from `UIMatch` in favour of `loaderData`. The breadcrumb builder still read `match.data`, so every `crumb()` callback got `undefined` and any route with a data-driven crumb crashed with: